### PR TITLE
Update README.md: Add "Get in on" buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 M3U is my first elaborate Android project and is also my first jetpack compose application project.
 
+<a href="https://github.com/realOxy/M3UAndroid/releases/latest"><img src="https://github.com/realOxy/M3UAndroid/assets/5572928/c407b17c-f64f-4486-ade1-6048eb177e67" height="80px"></a>
+<a href="https://apt.izzysoft.de/fdroid/index/apk/com.m3u.androidApp"><img src="https://github.com/realOxy/M3UAndroid/assets/5572928/4ba5a44a-c5e4-4634-a7aa-b8dda0992ba2" height="80px"></a>
+
 ![playlist](.github/images/playlist.png)
 ![setting](.github/images/setting.png)
 ![stream](.github/images/stream.png)


### PR DESCRIPTION
This PR contains the "Get in on" buttons for easy access to download the APKs from Fithub or the IzzyonDroid store. Like several repositories, I suggest you include these buttons on the README page. If these images disappear, I hope it does not happen, they will be upload later.