### PR TITLE
Update spanish translation + add information for fastlane metadata

### DIFF
--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -1,0 +1,1 @@
+Reproductor de streaming LIBRE para Android, hecho con Jetpack Componer. Para Android 8.0 y posteriores.

--- a/fastlane/metadata/android/es-ES/short_description.txt
+++ b/fastlane/metadata/android/es-ES/short_description.txt
@@ -1,0 +1,1 @@
+Reproductor de streaming LIBRE para Android.

--- a/i18n/src/main/res/values-es-rES/feat_playlist.xml
+++ b/i18n/src/main/res/values-es-rES/feat_playlist.xml
@@ -14,4 +14,5 @@
     <string name="feat_playlist_error_stream_not_found">el directo no existe</string>
     <string name="feat_playlist_success_save_cover">guardada to (%s)</string>
     <string name="feat_playlist_refreshing">actualizando</string>
+    <string name="feat_playlist_scroll_up">subir</string>
 </resources>

--- a/i18n/src/main/res/values-es-rES/feat_setting.xml
+++ b/i18n/src/main/res/values-es-rES/feat_setting.xml
@@ -11,9 +11,6 @@
     <string name="feat_setting_sync_mode_all">todo</string>
     <string name="feat_setting_sync_mode_skip_favourite">saltar favorito</string>
     <string name="feat_setting_sync_mode">modo de sincronización</string>
-    <string name="feat_setting_common_ui_mode">modo UI</string>
-    <string name="feat_setting_common_ui_mode_description">usar modo UI de dispositivo móvil</string>
-    <string name="feat_setting_common_ui_mode_disabled_description">el dispostivo móvil no permite ajustarlo</string>
     <string name="feat_setting_script_management">administrar script</string>
     <string name="feat_setting_playlist_management">administrar playlist</string>
     <string name="feat_setting_connect_timeout">límite de conexión</string>
@@ -62,5 +59,9 @@
     <string name="feat_setting_optional_player_features">características opcionales de reproducción</string>
     <string name="feat_setting_unseen_limit">recomendar streams favoritos vistos muy antes</string>
     <string name="feat_setting_reconnect_mode">auto reconectar</string>
+    <string name="feat_setting_reconnect_mode_no">nunca</string>
+    <string name="feat_setting_reconnect_mode_retry">solo si falla</string>
+    <string name="feat_setting_reconnect_mode_reconnect">siempre</string>
     <string name="feat_setting_compact">modo compacto</string>
+        <string name="feat_setting_appearance">apariencia</string>
 </resources>

--- a/i18n/src/main/res/values-es-rES/ui.xml
+++ b/i18n/src/main/res/values-es-rES/ui.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ui_title_foryou">M3U</string>
-
     <string name="ui_destination_foryou">Para Ti</string>
     <string name="ui_destination_favourite">Favoritos</string>
     <string name="ui_destination_setting">Ajustes</string>


### PR DESCRIPTION
This PR adds more text in Spanish-language and also adds information in Fastlane.